### PR TITLE
Add the load path of library on macOS 

### DIFF
--- a/libraries.lisp
+++ b/libraries.lisp
@@ -10,6 +10,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (cffi:define-foreign-library grpc-client-wrapper
+	;; Load lib on mac
 	(:darwin (:default "libgrpc"))
     ;; Load the C wrapper directly from the source directory.
     (t (:default #.(namestring

--- a/libraries.lisp
+++ b/libraries.lisp
@@ -10,6 +10,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (cffi:define-foreign-library grpc-client-wrapper
+	(:darwin (:default "libgrpc"))
     ;; Load the C wrapper directly from the source directory.
     (t (:default #.(namestring
                     (asdf:system-relative-pathname "grpc" "grpc")))))


### PR DESCRIPTION
Update the load condition that can load the grpc library that installed by homebrew on macOS

issue: #44 