### PR TITLE
use unsigned-char for byte conversion

### DIFF
--- a/shared.lisp
+++ b/shared.lisp
@@ -367,7 +367,7 @@ i of grpc_byte_buffer BUFFER."
 
 (defun convert-bytes-to-grpc-byte-buffer (bytes)
   "Given a lisp-vector of BYTES convert them to a grpc_byte_buffer."
-  (let ((array (cffi:foreign-alloc :char :initial-contents bytes)))
+  (let ((array (cffi:foreign-alloc :unsigned-char :initial-contents bytes)))
     (prog1
         (cffi:foreign-funcall "convert_bytes_to_grpc_byte_buffer"
                                :pointer array
@@ -536,7 +536,7 @@ want. Returns a plist containing keys being the op type and values being the ind
 (defun convert-bytes-to-grpc-slice (bytes)
   "Takes a list of bytes BYTES and returns a pointer to the corresponding
 grpc_slice*."
-  (let ((array (cffi:foreign-alloc :char :initial-contents bytes)))
+  (let ((array (cffi:foreign-alloc :unsigned-char :initial-contents bytes)))
     (cffi:foreign-funcall "convert_bytes_to_grpc_slice"
                           :pointer array
                           :size (length bytes)


### PR DESCRIPTION
I've been recieving this error when attempting to send a request to a grpc server:

```
debugger invoked on a TYPE-ERROR @536E6A8B in thread
#<THREAD tid=1452194 "main thread" RUNNING {1001710003}>:
  The value
    128
  is not of type
    (SIGNED-BYTE 8)
```

I think what's failing is the way that cffi does type conversion, and my system is using signed chars for some reason

I compiled `grpc.so` by using `make` in the directory with no additional configurations (`-B` causes it to execute as if it hadn't done so before)

```console
$ make -B
g++ -DNOMINMAX -pthread -I/usr/local/include -fPIC   -c -o client.o client.cc
g++ -DNOMINMAX -pthread -I/usr/local/include -fPIC   -c -o client_auth.o client_auth.cc
g++ -DNOMINMAX -pthread -I/usr/local/include -fPIC   -c -o server.o server.cc
g++  -pthread -shared -Wl,--no-undefined client.o client_auth.o server.o -o grpc.so -L/usr/local/lib -lgrpc -lgpr
```

system information:

- SBCL 2.3.9
- Linux 6.9.3-arch1-1 x86_64
- g++ (GCC) 14.1.1 20240522