### PR TITLE
Add support for a deadline on clients

### DIFF
--- a/client.cc
+++ b/client.cc
@@ -47,7 +47,7 @@ grpc_call* lisp_grpc_channel_create_call(grpc_channel* channel,
   if (deadline_seconds != nullptr) {
     send_deadline = grpc_timeout_seconds_to_deadline(*deadline_seconds);
   } else {
-    deadline = gpr_inf_future(GPR_CLOCK_MONOTONIC);
+    send_deadline = gpr_inf_future(GPR_CLOCK_MONOTONIC);
   }
 
   return grpc_channel_create_call(

--- a/grpc.lisp
+++ b/grpc.lisp
@@ -18,4 +18,5 @@
    #:with-insecure-channel
    #:with-ssl-channel
    #:grpc-call
-   #:check-server-status))
+   #:check-server-status
+   #:*call-deadline*))

--- a/shared.lisp
+++ b/shared.lisp
@@ -21,6 +21,9 @@
 (defvar *completion-queue* nil "The global completion queue used to
 manage grpc calls.")
 
+(defvar *call-deadline* nil
+  "The deadline for a grpc call. The default, nil, specifies an infinite deadline")
+
 ;; gRPC Enums
 (cffi:defcenum grpc-security-level
   "Security levels of grpc transport security. It represents an inherent

--- a/tests/integration-test.lisp
+++ b/tests/integration-test.lisp
@@ -77,6 +77,7 @@ Parameters
   (grpc:shutdown-grpc))
 
 (deftest test-client-server-deadline-can-set (server-suite)
+  "TODO(michaeldelago): The server should receive the deadline and be able to confirm that it's set"
   (grpc:init-grpc)
   (unwind-protect
        (let* ((expected-client-response "Hello World Back")
@@ -102,8 +103,8 @@ Parameters
              (bordeaux-threads:join-thread thread)))))
   (grpc:shutdown-grpc))
 
-;; TODO(michaeldelago): make it fail if the deadline gets exceeded
 (deftest test-client-server-deadline-can-fail (server-suite)
+  "TODO(michaeldelago): The server should return an error if the deadline is too high"
   (grpc:init-grpc)
   (unwind-protect
        (let* ((expected-client-response "Hello World Back")

--- a/tests/integration-test.lisp
+++ b/tests/integration-test.lisp
@@ -40,8 +40,8 @@ Parameters
         :utf-8))
      :action
      (lambda (message call)
-       (declare (ignore call))
-       (format t "~% response: ~A ~%" message)
+       (format t "~% call: ~A ~%" call)
+       (format t " response: ~A ~%" message)
        (concatenate 'string
                     message
                     " Back"))))
@@ -76,7 +76,34 @@ Parameters
              (bordeaux-threads:join-thread thread)))))
   (grpc:shutdown-grpc))
 
-(deftest test-client-server-deadline (server-suite)
+(deftest test-client-server-deadline-can-set (server-suite)
+  (grpc:init-grpc)
+  (unwind-protect
+       (let* ((expected-client-response "Hello World Back")
+              (hostname "localhost")
+              (method-name "xyz")
+              (port-number 8000)
+              (sem (bordeaux-threads:make-semaphore))
+              (thread (bordeaux-threads:make-thread
+                       (lambda () (run-server sem hostname method-name
+                                              port-number)))))
+         (bordeaux-threads:wait-on-semaphore sem)
+         (grpc:with-insecure-channel
+             (channel
+              (concatenate 'string hostname ":" (write-to-string port-number)))
+           (let* ((grpc::*call-deadline* 3)
+                  (message "Hello World")
+                  (response (grpc:grpc-call channel method-name
+                                            (flexi-streams:string-to-octets message)
+                                            nil nil))
+                  (actual-client-response (flexi-streams:octets-to-string
+                                           (car response))))
+             (assert-true (string=  actual-client-response expected-client-response))
+             (bordeaux-threads:join-thread thread)))))
+  (grpc:shutdown-grpc))
+
+;; TODO(michaeldelago): make it fail if the deadline gets exceeded
+(deftest test-client-server-deadline-can-fail (server-suite)
   (grpc:init-grpc)
   (unwind-protect
        (let* ((expected-client-response "Hello World Back")


### PR DESCRIPTION
This PR sets up a basic implementation for deadlines from grpc clients. This is roughly described in #68 

**Request for comments** - what do we think of this implementation? is there a better way we can do it? My goal is to keep the syntax for setting the deadline relatively ergonomic in the code. Ideally we'd be able to add the other parameters to fill out the C signature for `grpc_channel_create_call` ([used here](https://github.com/qitab/grpc/blob/917dd00b3add7fc9fc17ccb73af3662f96edea83/client.cc#L47)).

Open TODO's:

- tests
  - [ ] asserting that the server can receive the deadline and confirm it's properly set
  - [ ] asserting that the server fails on a deadline and signals the appropriate condition